### PR TITLE
Release 1.3.1

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 1.3.0
-Date: 2024-01-09 19:31:21 UTC
-SHA: e5500ba623c38eecbf21ba4e990d78daa8ad8e99
+Version: 1.3.1
+Date: 2024-01-12 17:59:54 UTC
+SHA: 8cedba659d3e66120e4224e82361e1d2faae45aa

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: profoc
 Type: Package
 Title: Probabilistic Forecast Combination Using CRPS Learning
 Version: 1.3.1
-Date: 2024-01-09
+Date: 2024-01-12
 Authors@R: c(
     person(given = "Jonathan",
              family = "Berrisch",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: profoc
 Type: Package
 Title: Probabilistic Forecast Combination Using CRPS Learning
-Version: 1.3.0
+Version: 1.3.1
 Date: 2024-01-09
 Authors@R: c(
     person(given = "Jonathan",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+profoc 1.3.1
+==============
+
+## Improvements
+* Adjusted the clock.h code so that a larger share of code can be shared between the R and Python versions of that file.
+
+## Fixes
+* Fixed an integer overflow in the clock.h code which caused the package to fail on some systems.
+* Fixed online() function for cases where the regret is exactly zero. This can happen if:
+* * Only a single expert is used
+* * Only two experts are provided and they both have the same predictions (in the beginning).
+
 profoc 1.3.0
 ==============
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ profoc 1.3.1
 
 ## Improvements
 * Adjusted the clock.h code so that a larger share of code can be shared between the R and Python versions of that file.
+* clock.h now uses welfords online algorithm to calculate the mean and variance of the timings. SD is reported in the times table.
 
 ## Fixes
 * Fixed an integer overflow in the clock.h code which caused the package to fail on some systems.

--- a/inst/include/clock.h
+++ b/inst/include/clock.h
@@ -31,7 +31,7 @@ namespace Rcpp
     private:
         timesmap tickmap;
         std::vector<double> averages;
-        std::vector<unsigned int> counts;
+        std::vector<unsigned long int> counts;
         std::vector<std::string> unique_names;
 
     public:

--- a/inst/include/clock.h
+++ b/inst/include/clock.h
@@ -25,7 +25,7 @@ namespace Rcpp
     class Clock
     {
         using tp = sc::high_resolution_clock::time_point;
-        using keypair = std::pair<std::string, int>;
+        using keypair = std::pair<std::string, unsigned int>;
         using timesmap = std::map<keypair, tp>;
 
     private:
@@ -33,7 +33,7 @@ namespace Rcpp
 
     public:
         std::string name;
-        std::vector<double> timers;
+        std::vector<unsigned long long int> timers;
         std::vector<std::string> names;
 
         // Init - Set name of R object
@@ -58,7 +58,7 @@ namespace Rcpp
 #pragma omp critical
             {
                 timers.push_back(
-                    sc::duration_cast<sc::nanoseconds>(
+                    sc::duration_cast<sc::microseconds>(
                         sc::high_resolution_clock::now() -
                         tickmap[key])
                         .count());
@@ -73,30 +73,29 @@ namespace Rcpp
             std::vector<std::string> unique_names = names;
             remove_duplicates(unique_names);
 
-            std::vector<std::tuple<std::string, double, int>>
-                table(unique_names.size());
-
             std::vector<double> averages(unique_names.size());
-            std::vector<int> counts(unique_names.size());
+            std::vector<unsigned long int> counts(unique_names.size());
 
             // Loop over unique names
             for (unsigned int i = 0; i < unique_names.size(); i++)
             {
-                int sum = 0;
-                int count = 0;
+                unsigned long long int sum = 0;
+                unsigned long int count = 0;
 
                 // Loop over all names
-                for (unsigned int j = 0; j < names.size(); j++)
+                for (unsigned long int j = 0; j < names.size(); j++)
                 {
                     if (names[j] == unique_names[i])
                     {
+                        // Sum up all timers with the same name
                         sum += timers[j];
                         count++;
                     }
                 }
 
-                // Calculate average, convert to milliseconds, round to 3 dec
-                averages[i] = (std::round((sum * 1e-3) / double(count)) / 1e+3);
+                // Calculate average, round to 3 decimal places,
+                // and convert from microseconds to milliseconds
+                averages[i] = std::round(sum / double(count)) / 1e+3;
                 counts[i] = count;
             }
 

--- a/inst/include/clock.h
+++ b/inst/include/clock.h
@@ -106,12 +106,12 @@ namespace Rcpp
         {
             aggregate();
 
-            // DataFrame df = DataFrame::create(
-            //     Named("Name") = unique_names,
-            //     Named("Milliseconds") = averages,
-            //     Named("Count") = counts);
-            // Environment env = Environment::global_env();
-            // env[name] = df;
+            DataFrame df = DataFrame::create(
+                Named("Name") = unique_names,
+                Named("Milliseconds") = averages,
+                Named("Count") = counts);
+            Environment env = Environment::global_env();
+            env[name] = df;
         }
 
         // Destructor

--- a/inst/include/clock.h
+++ b/inst/include/clock.h
@@ -106,12 +106,12 @@ namespace Rcpp
         {
             aggregate();
 
-            DataFrame df = DataFrame::create(
-                Named("Name") = unique_names,
-                Named("Milliseconds") = averages,
-                Named("Count") = counts);
-            Environment env = Environment::global_env();
-            env[name] = df;
+            // DataFrame df = DataFrame::create(
+            //     Named("Name") = unique_names,
+            //     Named("Milliseconds") = averages,
+            //     Named("Count") = counts);
+            // Environment env = Environment::global_env();
+            // env[name] = df;
         }
 
         // Destructor

--- a/inst/include/clock.h
+++ b/inst/include/clock.h
@@ -30,6 +30,9 @@ namespace Rcpp
 
     private:
         timesmap tickmap;
+        std::vector<double> averages;
+        std::vector<unsigned int> counts;
+        std::vector<std::string> unique_names;
 
     public:
         std::string name;
@@ -70,11 +73,8 @@ namespace Rcpp
         void aggregate()
         {
             // Create copy of names called unique_names
-            std::vector<std::string> unique_names = names;
+            unique_names = names;
             remove_duplicates(unique_names);
-
-            std::vector<double> averages(unique_names.size());
-            std::vector<unsigned long int> counts(unique_names.size());
 
             // Loop over unique names
             for (unsigned int i = 0; i < unique_names.size(); i++)
@@ -95,9 +95,16 @@ namespace Rcpp
 
                 // Calculate average, round to 3 decimal places,
                 // and convert from microseconds to milliseconds
-                averages[i] = std::round(sum / double(count)) / 1e+3;
-                counts[i] = count;
+                averages.push_back(std::round(sum / double(count)) / 1e+3);
+
+                counts.push_back(count);
             }
+        }
+
+        // Pass data to R / Python
+        void stop()
+        {
+            aggregate();
 
             DataFrame df = DataFrame::create(
                 Named("Name") = unique_names,
@@ -105,11 +112,6 @@ namespace Rcpp
                 Named("Count") = counts);
             Environment env = Environment::global_env();
             env[name] = df;
-        }
-
-        void stop()
-        {
-            aggregate();
         }
 
         // Destructor

--- a/src/conline.cpp
+++ b/src/conline.cpp
@@ -380,12 +380,13 @@ void conline::learn()
                     {
                         V(x).tube(dr, pr) = vectorise(V(x).tube(dr, pr)).t() * (1 - params["forget_regret"](x)) + square(r.t());
 
-                        E(x).tube(dr, pr) = max(vectorise(E(x).tube(dr, pr)).t() * (1 - params["forget_regret"](x)), abs(r.t()));
+                        E(x).tube(dr, pr) = pmax_arma(max(vectorise(E(x).tube(dr, pr)).t() * (1 - params["forget_regret"](x)), abs(r.t())), exp(-350));
 
-                        eta(x).tube(dr, pr) =
+                        eta(x)
+                            .tube(dr, pr) =
                             pmin_arma(
                                 min(1 / (2 * vectorise(E(x).tube(dr, pr))),
-                                    sqrt(-log(vectorise(beta0field(x).tube(dr, pr))) / vectorise(V(x).tube(dr, pr)))),
+                                    sqrt(-log(vectorise(beta0field(x).tube(dr, pr))) / pmax_arma(vectorise(V(x).tube(dr, pr)), exp(-350)))),
                                 exp(350));
 
                         vec r_reg = r - vectorise(eta(x).tube(dr, pr)) % square(r);

--- a/tests/testthat/test-single_same_experts.R
+++ b/tests/testthat/test-single_same_experts.R
@@ -1,0 +1,40 @@
+skip_if(debug_mode)
+# %% Test online "combination" of a single expert
+set.seed(1)
+
+mod <- online(
+    y = array(rnorm(30),
+        dim = c(5, 3)
+    ), array(rnorm(30),
+        dim = c(5, 3, 1)
+    ),
+    tau = .5,
+    trace = FALSE
+)
+
+expect_true(all(mod$weights == 1))
+# %%
+
+
+# %% Test online "combination" of two experts that are the same
+set.seed(1)
+
+experts <- array(NA,
+    dim = c(5, 3, 2)
+)
+
+experts[, , 1] <- array(rnorm(30),
+    dim = c(5, 3)
+)
+experts[, , 2] <- experts[, , 1]
+
+mod <- online(
+    y = array(rnorm(30),
+        dim = c(5, 3)
+    ), experts,
+    tau = .5,
+    trace = FALSE
+)
+
+expect_true(all(mod$weights == 0.5))
+# %%


### PR DESCRIPTION
## Improvements
* Adjusted the clock.h code so that a larger share of code can be shared between the R and Python versions of that file.
* clock.h now uses welfords online algorithm to calculate the mean and variance of the timings. SD is reported in the times table.

## Fixes
* Fixed an integer overflow in the clock.h code which caused the package to fail on some systems.
* Fixed online() function for cases where the regret is exactly zero. This can happen if:
* * Only a single expert is used
* * Only two experts are provided and they both have the same predictions (in the beginning).

Note that CI checks where failing under ubuntu-latest due to https://github.com/RcppCore/Rcpp/issues/1287. This has been fixed.